### PR TITLE
Add os type to img compare (wip)

### DIFF
--- a/lib/eyes.js
+++ b/lib/eyes.js
@@ -12,6 +12,8 @@ const eyesBatchUuid = process.env.IS_BUILD_AGENT
   ? process.env.BUILD_NUMBER
   : uuid.v4();
 
+eyes.setOs(process.platform);
+
 if (process.env.EYES_API_KEY) {
   eyes.setApiKey(process.env.EYES_API_KEY);
   rewireGlobalsWithEyes(eyes, appName);

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -10,7 +10,7 @@ describe('Eyes with default version', () => {
     {fnName: 'test', fn: test},
   ].forEach(type => {
     type.fn(`should work for ${type.fnName}`, async () => {
-      const divText = 'Hi there!';
+      const divText = 'Hello World!';
       await global.page.setContent(`<div>${divText}</div>`);
       expect(await global.page.$eval('div', el => el.innerText)).toEqual(
         divText,


### PR DESCRIPTION
Fixes #13 - fonts are rendered differently on different os types (in "Hello World", the "W" was different between mac and linux, for example). This PR solves this